### PR TITLE
Fix set_limitpower

### DIFF
--- a/custom_components/saj_modbus/hub.py
+++ b/custom_components/saj_modbus/hub.py
@@ -316,7 +316,7 @@ class SAJModbusHub(DataUpdateCoordinator[dict]):
         """Limit the power output of the inverter."""
         if self.limiter_is_disabled():
             return
-        response = self._write_registers(unit=1, address=0x801F, values=int(value*10))
+        response = self._write_registers(unit=1, address=0x801F, values=[int(value*10)])
         if response.isError():
             return
         self.data["limitpower"] = value


### PR DESCRIPTION
Provide a list[int] as "values" argument to _write_registers

With the update to `pymodbus>=3.8.0` the accepted argument types for the `write_registers` method were reduced. We now need to provide a `list[int]`. This PR takes care of that.

fixes #103 