### PR TITLE
Modbus change for HA 2025.09

### DIFF
--- a/custom_components/saj_modbus/hub.py
+++ b/custom_components/saj_modbus/hub.py
@@ -88,14 +88,14 @@ class SAJModbusHub(DataUpdateCoordinator[dict[str, int | float | str]]):
         """Read holding registers."""
         with self._lock:
             return self._client.read_holding_registers(
-                address=address, count=count, slave=unit
+                address=address, count=count, device_id=unit
             )
 
     def _write_registers(self, unit: int, address: int, values: list[int]) -> ModbusPDU:
         """Write registers."""
         with self._lock:
             return self._client.write_registers(
-                address=address, values=values, slave=unit
+                address=address, values=values, device_id=unit
             )
 
     def convert_to_signed(self, value: int) -> int:

--- a/custom_components/saj_modbus/manifest.json
+++ b/custom_components/saj_modbus/manifest.json
@@ -5,7 +5,6 @@
     "@wimb0"
   ],
   "config_flow": true,
-  "requirements": ["pymodbus>=3.10"],
   "documentation": "https://github.com/wimb0/home-assistant-saj-r5-modbus",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/wimb0/home-assistant-saj-r5-modbus/issues",

--- a/custom_components/saj_modbus/manifest.json
+++ b/custom_components/saj_modbus/manifest.json
@@ -5,7 +5,7 @@
     "@wimb0"
   ],
   "config_flow": true,
-  "dependencies": [],
+  "requirements": ["pymodbus>=3.10"],
   "documentation": "https://github.com/wimb0/home-assistant-saj-r5-modbus",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/wimb0/home-assistant-saj-r5-modbus/issues",

--- a/custom_components/saj_modbus/manifest.json
+++ b/custom_components/saj_modbus/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/wimb0/home-assistant-saj-r5-modbus/issues",
   "requirements": [
-    "pymodbus>=3.7.4"
+    "pymodbus>=3.10"
   ],
   "version": "v3.1.0"
 }

--- a/custom_components/saj_modbus/manifest.json
+++ b/custom_components/saj_modbus/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "pymodbus>=3.10"
   ],
-  "version": "v3.1.0"
+  "version": "v3.1.2"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "SAJ R5 Inverter Modbus",
   "content_in_root": false,
-  "homeassistant": "2025.1.0",
+  "homeassistant": "2025.9.0",
   "render_readme": true,
   "country": "NL",
   "hide_default_branch": true,


### PR DESCRIPTION
In HA 2025.09, pymodbus is updated to 3.11.1.
Unfortunately this contains a backwards incompatible change:
See: https://pymodbus.readthedocs.io/en/latest/source/changelog.html#version-3-10-0 and https://github.com/pymodbus-dev/pymodbus/blob/dev/API_changes.rst#api-changes-3100

Fixes  https://github.com/wimb0/home-assistant-saj-r5-modbus/issues/176