### PR TITLE
Fix deprecation issues

### DIFF
--- a/custom_components/saj_modbus/config_flow.py
+++ b/custom_components/saj_modbus/config_flow.py
@@ -44,6 +44,12 @@ class SAJModbusConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 2
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Handle options flow."""
+        return SAJModbusOptionsFlowHandler(config_entry)
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -53,15 +59,6 @@ class SAJModbusConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             host = user_input[CONF_HOST]
 
-            data = {
-                CONF_NAME: user_input[CONF_NAME],
-                CONF_HOST: user_input[CONF_HOST],
-                CONF_PORT: user_input[CONF_PORT],
-            }
-            options = {
-                CONF_SCAN_INTERVAL: user_input[CONF_SCAN_INTERVAL],
-            }
-
             if host in saj_modbus_entries(self.hass):
                 errors[CONF_HOST] = "already_configured"
             elif not host_valid(host):
@@ -70,7 +67,7 @@ class SAJModbusConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(host)
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(
-                    title=data[CONF_NAME], data=data, options=options
+                    title=user_input[CONF_NAME], data=user_input
                 )
 
         setup_schema = vol.Schema(
@@ -88,19 +85,13 @@ class SAJModbusConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=setup_schema, errors=errors
         )
 
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
-        """Handle options flow."""
-        return SAJModbusOptionsFlowHandler(config_entry)
-
 
 class SAJModbusOptionsFlowHandler(OptionsFlow):
     """SAJ Modbus config flow options handler."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
+        super().__init__(config_entry)
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -112,32 +103,26 @@ class SAJModbusOptionsFlowHandler(OptionsFlow):
             if not host_valid(user_input[CONF_HOST]):
                 errors[CONF_HOST] = "invalid_host"
             else:
-                new_data = self.config_entry.data.copy()
-                new_data[CONF_HOST] = user_input[CONF_HOST]
-                new_data[CONF_PORT] = user_input[CONF_PORT]
-
-                new_options = self.config_entry.options.copy()
-                new_options[CONF_SCAN_INTERVAL] = user_input[CONF_SCAN_INTERVAL]
-
                 self.hass.config_entries.async_update_entry(
-                    self.config_entry, data=new_data, options=new_options
+                    self.config_entry, data=user_input
                 )
-
                 return self.async_abort(reason="reconfigure_successful")
-
-        current_host = self.config_entry.data.get(CONF_HOST)
-        current_port = self.config_entry.data.get(CONF_PORT, DEFAULT_PORT)
-        current_scan_interval = self.config_entry.options.get(
-            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
-        )
 
         options_schema = vol.Schema(
             {
-                vol.Required(CONF_HOST, default=current_host): str,
-                vol.Required(CONF_PORT, default=current_port): int,
-                vol.Optional(CONF_SCAN_INTERVAL, default=current_scan_interval): vol.All(
-                    vol.Coerce(int), vol.Range(min=1, max=600)
-                ),
+                vol.Required(
+                    CONF_HOST, default=self.config_entry.data.get(CONF_HOST)
+                ): str,
+                vol.Required(
+                    CONF_PORT,
+                    default=self.config_entry.data.get(CONF_PORT, DEFAULT_PORT),
+                ): int,
+                vol.Optional(
+                    CONF_SCAN_INTERVAL,
+                    default=self.config_entry.options.get(
+                        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                    ),
+                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=600)),
             }
         )
 

--- a/custom_components/saj_modbus/manifest.json
+++ b/custom_components/saj_modbus/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pymodbus>=3.10"
   ],
-  "version": "v3.1.2"
+  "version": "v3.1.3"
 }


### PR DESCRIPTION
Detected that custom integration 'saj_modbus' sets option flow config_entry explicitly, which is deprecated at custom_components/saj_modbus/config_flow.py, line 103: self.config_entry = config_entry. This will stop working in Home Assistant 2025.12, please create a bug report at https://github.com/wimb0/home-assistant-saj-r5-modbus/issues

Detected that custom integration 'saj_modbus' uses async_config_entry_first_refresh, which is only supported for coordinators with a config entry at custom_components/saj_modbus/init.py, line 42: await hub.async_config_entry_first_refresh(). This will stop working in Home Assistant 2025.11, please create a bug report at https://github.com/wimb0/home-assistant-saj-r5-modbus/issues

Should fix #182